### PR TITLE
Arreglar issue #19

### DIFF
--- a/API/ClientApp/src/api/api.js
+++ b/API/ClientApp/src/api/api.js
@@ -57,7 +57,9 @@ export const hacerPeticion = async (peticion) => {
  * @param {string} endpoint El endpoint que realiza la acción.
  * @param {number} numPagina El número de la página.
  * @param {number} elemsPorPagina El número de elementos por página.
+ * @param {object} paramsExtra Un mapa con parámetros de query adicionales.
  * @param {string} jwt El token de autenticación del usuario.
+ * @param {boolean} incluirIdUsuario Si la petición debería incluir el ID del usuario actual en parámetros de query.
  * @returns Una respuesta con los resultados paginados, o un error.
  */
 export async function fetchPaginado(endpoint, numPagina = 1, elemsPorPagina = 25, paramsExtra = null, jwt = "", incluirIdUsuario = false) {

--- a/API/ClientApp/src/api/api_comentarios.js
+++ b/API/ClientApp/src/api/api_comentarios.js
@@ -5,7 +5,7 @@ export const fetchComentariosPublicados = async (numPagina = 1, jwt = "") => {
 
   const endpoint = "comentarios";
 
-  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, jwt);
+  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt, false);
   
   return resultados;
 }
@@ -99,7 +99,7 @@ export const fetchComentariosDeAutor = async (idAutor, numPagina = 1, jwt = "") 
 
   console.log(numPagina);
 
-  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, jwt);
+  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt, false);
   
   return resultados;
 }
@@ -108,7 +108,7 @@ export const fetchComentariosPendientes = async (numPagina = 1, jwt = "") => {
 
   const endpoint = "comentarios/pendientes";
 
-  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, jwt);
+  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt, false);
   
   return resultados;
 }
@@ -223,7 +223,7 @@ export const fetchRespuestasAComentario = async (idComentario, numPagina = 1, jw
 
   const endpoint = `comentarios/${idComentario}/respuestas`;
 
-  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, jwt);
+  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt, false);
   
   return resultados;
 }

--- a/API/ClientApp/src/api/api_llaves.js
+++ b/API/ClientApp/src/api/api_llaves.js
@@ -5,7 +5,7 @@ export const fetchLlavesDeApiComoAdmin = async (numPagina = 1, jwt = "") => {
 
 	const endpoint = "llaves";
 
-	const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt);
+	const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt, false);
 	
 	return resultados;
 }

--- a/API/ClientApp/src/api/api_recursos.js
+++ b/API/ClientApp/src/api/api_recursos.js
@@ -4,7 +4,7 @@ export const fetchRecursos = async (numPagina = 1, jwt = "") => {
 
   const endpoint = "recursos";
 
-  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, jwt);
+  const resultados = await api.fetchPaginado(endpoint, numPagina, api.SIZE_PAGINA_DEFAULT, null, jwt);
   
   return resultados;
 }


### PR DESCRIPTION
El problema era que en un punto, la signature de `fetchPaginado()` había cambiado, y el token de autenticación cambió de posición en los parámetros de la función. Esto hacía que el token fuera pasado como argumento de `extraParams`, en vez de `jwt`. Por esto se producían los errores al hacer peticiones que requieren de autenticación usando la función `fetchPaginado()`.