### PR TITLE
Arreglar bug en uso de fetchRespuestasAComentario()

### DIFF
--- a/API/ClientApp/src/components/Tarjetas/tarjeta_comentario.js
+++ b/API/ClientApp/src/components/Tarjetas/tarjeta_comentario.js
@@ -188,7 +188,7 @@ export default function TarjetaComentario(props) {
 
 			// Obtener todas las respuestas al comentario. Ya vienen ordenados por
 			// fecha desde la API.
-			const resultado = await api.fetchRespuestasAComentario(comentario.id, jwt);
+			const resultado = await api.fetchRespuestasAComentario(comentario.id, 1, jwt);
 
 			console.log(resultado);
 


### PR DESCRIPTION
Al invocar `fetchRespuestasAComentario()`, se estaba pasando el token de autenticación como el número de página de resultados. Arreglado temporalmente usando una sola página.