### PR TITLE
Arreglar issue #33 cambiando asignación de PK a registros

### DIFF
--- a/API/Migrations/MySQL/ContextoDBMysqlModelSnapshot.cs
+++ b/API/Migrations/MySQL/ContextoDBMysqlModelSnapshot.cs
@@ -148,7 +148,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("AutorId");
 
-                    b.ToTable("Comentarios");
+                    b.ToTable("Comentarios", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.ComentarioArchivado", b =>
@@ -169,7 +169,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("ComentariosArchivados");
+                    b.ToTable("ComentariosArchivados", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Configuracion", b =>
@@ -209,7 +209,7 @@ namespace ServicioHydrate.Migrations.MySQL
                     b.HasIndex("IdPerfil")
                         .IsUnique();
 
-                    b.ToTable("Configuracion");
+                    b.ToTable("Configuracion", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.DatosMedicos", b =>
@@ -248,7 +248,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdPerfil");
 
-                    b.ToTable("DatosMedicos");
+                    b.ToTable("DatosMedicos", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.Etiqueta", b =>
@@ -267,7 +267,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdPerfil");
 
-                    b.ToTable("Etiquetas");
+                    b.ToTable("Etiquetas", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.MetaHidratacion", b =>
@@ -304,7 +304,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdPerfil");
 
-                    b.ToTable("Metas");
+                    b.ToTable("Metas", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.RegistroDeActividad", b =>
@@ -347,7 +347,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdTipoDeActividad");
 
-                    b.ToTable("RegistrosDeActFisica");
+                    b.ToTable("RegistrosDeActFisica", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.RegistroDeHidratacion", b =>
@@ -378,7 +378,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdPerfil");
 
-                    b.ToTable("RegistrosDeHidratacion");
+                    b.ToTable("RegistrosDeHidratacion", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.ReporteSemanal", b =>
@@ -408,7 +408,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdPerfil");
 
-                    b.ToTable("ReporteSemanal");
+                    b.ToTable("ReporteSemanal", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.Rutina", b =>
@@ -437,7 +437,7 @@ namespace ServicioHydrate.Migrations.MySQL
                     b.HasIndex("IdActividad", "IdPerfil")
                         .IsUnique();
 
-                    b.ToTable("RutinasDeActFisica");
+                    b.ToTable("RutinasDeActFisica", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Datos.TipoDeActividad", b =>
@@ -457,7 +457,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("TiposDeActividad");
+                    b.ToTable("TiposDeActividad", (string)null);
 
                     b.HasData(
                         new
@@ -539,7 +539,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("Entornos");
+                    b.ToTable("Entornos", (string)null);
 
                     b.HasData(
                         new
@@ -587,7 +587,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdUsuario");
 
-                    b.ToTable("LlavesDeAPI");
+                    b.ToTable("LlavesDeAPI", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Orden", b =>
@@ -610,7 +610,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("ClienteId");
 
-                    b.ToTable("Ordenes");
+                    b.ToTable("Ordenes", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Pais", b =>
@@ -624,7 +624,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("Paises");
+                    b.ToTable("Paises", (string)null);
 
                     b.HasData(
                         new
@@ -707,7 +707,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdPaisDeResidencia");
 
-                    b.ToTable("Perfiles");
+                    b.ToTable("Perfiles", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Producto", b =>
@@ -737,7 +737,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("Productos");
+                    b.ToTable("Productos", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.ProductosOrdenados", b =>
@@ -755,7 +755,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdProducto");
 
-                    b.ToTable("ProductosOrdenados");
+                    b.ToTable("ProductosOrdenados", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.RecursoInformativo", b =>
@@ -784,7 +784,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("Recursos");
+                    b.ToTable("Recursos", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Respuesta", b =>
@@ -817,7 +817,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasIndex("IdComentario");
 
-                    b.ToTable("Respuestas");
+                    b.ToTable("Respuestas", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.TokenFCM", b =>
@@ -844,7 +844,7 @@ namespace ServicioHydrate.Migrations.MySQL
                     b.HasIndex("IdPerfil")
                         .IsUnique();
 
-                    b.ToTable("TokensFCM");
+                    b.ToTable("TokensFCM", (string)null);
                 });
 
             modelBuilder.Entity("ServicioHydrate.Modelos.Usuario", b =>
@@ -871,7 +871,7 @@ namespace ServicioHydrate.Migrations.MySQL
 
                     b.HasKey("Id");
 
-                    b.ToTable("Usuarios");
+                    b.ToTable("Usuarios", (string)null);
                 });
 
             modelBuilder.Entity("ComentarioUsuario", b =>

--- a/API/Models/DTO/Datos/DTONuevaActividad.cs
+++ b/API/Models/DTO/Datos/DTONuevaActividad.cs
@@ -51,9 +51,11 @@ namespace ServicioHydrate.Modelos.DTO.Datos
                 throw new FormatException("Se esperaba un string con formato ISO 8601, pero el string recibido no es válido");  
             }
 
+            int idPerfilAsociado = esParteDeDatosAbiertos ? Perfil.perfilServicio.Id : IdPerfil;
+
             return new RegistroDeActividad
             {
-                IdPerfil = this.IdPerfil,
+                IdPerfil = idPerfilAsociado,
                 Titulo = this.Titulo,
                 Fecha = fecha,
                 Duracion = this.Duracion,

--- a/API/Models/DTO/Datos/DTORegistroHidratacion.cs
+++ b/API/Models/DTO/Datos/DTORegistroHidratacion.cs
@@ -33,14 +33,15 @@ namespace ServicioHydrate.Modelos.DTO.Datos
                 throw new FormatException("Se esperaba un string con formato ISO 8601, pero el string recibido no es válido");  
             }
 
+			int idPerfilAsociado = esParteDeDatosAbiertos ? Perfil.perfilServicio.Id : perfilDeUsuario.Id;
+
 			return new RegistroDeHidratacion 
 			{
-				Id = this.Id,
+				IdPerfil = idPerfilAsociado,
 				CantidadEnMl = this.CantidadEnMl,
                 PorcentajeCargaBateria = this.PorcentajeCargaBateria,
                 TemperaturaAproximada = this.TemperaturaAproximada,
                 Fecha = fecha,
-                Perfil = perfilDeUsuario,
 				EsInformacionAbierta = esParteDeDatosAbiertos,
 			};
 		}

--- a/API/Models/Perfil.cs
+++ b/API/Models/Perfil.cs
@@ -68,6 +68,31 @@ namespace ServicioHydrate.Modelos
 		public virtual ICollection<RegistroDeHidratacion> RegistrosDeHidratacion { get; set; }
 		public virtual ICollection<Rutina> Rutinas { get; set; }
 
+		[NotMapped]
+		private static Perfil _perfilCuentaServicio = new Perfil
+		{
+			Id = 5,
+			IdCuentaUsuario = new Guid("08dabc24-80c4-4416-8ff9-07c23b71fcf6"),
+			Nombre = "Cuenta",
+			Apellido = "Servicio",
+			FechaNacimiento = DateTime.Now.ToString("o"),
+			SexoUsuario = SexoUsuario.NO_ESPECIFICADO,
+			Estatura = 0.0,
+			Peso = 0.0,
+			Ocupacion = Ocupacion.NO_ESPECIFICADO,
+			IdPaisDeResidencia = Pais.PaisNoEspecificado.Id,
+			CondicionMedica = CondicionMedica.NO_ESPECIFICADO,
+			CantidadMonedas = 0,
+			NumModificaciones = 0,
+			IdEntornoSeleccionado = Entorno.PrimerEntornoDesbloqueado.Id,
+			EntornosDesbloqueados = new List<Entorno>(),
+			FechaSyncConGoogleFit = null,
+			FechaDeCreacion = DateTime.Now,
+			FechaDeModificacion = null,
+		};
+
+		public static Perfil perfilServicio { get => _perfilCuentaServicio; }
+
         public static Perfil PorDefecto(Guid? idCuentaUsuario) 
         {
             return new Perfil


### PR DESCRIPTION
Para solucionar el problema con llaves primarias de registros de actividad e hidratación, todos los registros contribuidos como datos abiertos ahora reciben el ID de perfil de una cuenta de administración, para evitar que puedan tener el mismo ID y el mismo IdPerfil que otros registros sincronizados por el mismo usuario.